### PR TITLE
Treesitter node types fix

### DIFF
--- a/lua/autoinst/init.lua
+++ b/lua/autoinst/init.lua
@@ -25,11 +25,11 @@ end
 
 local function get_header_items(file_path)
 	local stext = io.open(file_path):read("*a")
-	local name = get_query(stext, "(module_header (simple_identifier) @module_name)")
+	local name = get_query(stext, "((module_keyword) (simple_identifier) @module_name)")
 	local params = {
 		idents = get_query(
 			stext,
-			"(parameter_declaration (list_of_param_assignments (param_assignment (parameter_identifier) @param_name )))"
+			"(parameter_declaration (list_of_param_assignments (param_assignment (simple_identifier) @param_name )))"
 		),
 		consts = get_query(
 			stext,
@@ -37,7 +37,7 @@ local function get_header_items(file_path)
 		),
 	}
 
-	local ports = get_query(stext, "(ansi_port_declaration (port_identifier) @port_name)")
+	local ports = get_query(stext, "(ansi_port_declaration (simple_identifier) @port_name)")
 
 	if not name or not params or not ports then
 		vim.notify("Failed to get query")


### PR DESCRIPTION
Nodes types rename to fix [issue](https://github.com/mingo99/verilog-autoinst.nvim/issues/2)