### PR TITLE
Simple fixes

### DIFF
--- a/lua/autoinst/init.lua
+++ b/lua/autoinst/init.lua
@@ -37,7 +37,7 @@ local function get_header_items(file_path)
 		),
 	}
 
-	local ports = get_query(stext, "(ansi_port_declaration (simple_identifier) @port_name)")
+	local ports = get_query(stext, "[(ansi_port_declaration (simple_identifier) @ansi_name) (port (simple_identifier) @nonansi_name)]")
 
 	if not name or not params or not ports then
 		vim.notify("Failed to get query")

--- a/lua/autoinst/util.lua
+++ b/lua/autoinst/util.lua
@@ -15,7 +15,7 @@ function M.get_root()
 	---@type string[]
 	local roots = {}
 	if path then
-		for _, client in pairs(vim.lsp.get_active_clients({ bufnr = 0 })) do
+		for _, client in pairs(vim.lsp.get_clients({ bufnr = 0 })) do
 			local workspace = client.config.workspace_folders
 			local paths = workspace
 					and vim.tbl_map(function(ws)
@@ -24,9 +24,11 @@ function M.get_root()
 				or client.config.root_dir and { client.config.root_dir }
 				or {}
 			for _, p in ipairs(paths) do
-				local r = vim.loop.fs_realpath(p)
-				if path:find(r, 1, true) then
-					roots[#roots + 1] = r
+				if p ~= "" then
+					local r = vim.loop.fs_realpath(p)
+					if path:find(r, 1, true) then
+						roots[#roots + 1] = r
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Some simple fixes:
1. Added support for non-ansi port declarations
2. Checked for the path returned by the LSP to be non-empty since some null LSPs return empty strings
3. Switched from get_active_clients to get_clients to avoid deprecation warning